### PR TITLE
Add relay tunneling between peers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,12 @@
 
 Ribbon Worm aims to create an encrypted, mesh-like network between machines
 on the same LAN. The prototype uses mDNS for peer discovery and then
-attempts to establish SOCKS5 connections between discovered hosts.
+attempts to establish SOCKS5 connections between discovered hosts. As of
+this version, each node also rebroadcasts its known peers so that hosts can
+discover machines that are not directly reachable. A lightweight relay server
+now runs on each node and will forward traffic between peers. If a direct
+connection fails, nodes attempt to contact the destination via any other known
+peer, creating a simple tunnel through the network.
 
 ## Building
 
@@ -21,4 +26,6 @@ java ribbonWorm_Main
 ```
 
 The application will broadcast discovery packets once per second and attempt
-to connect to newly discovered peers through the local SOCKS5 proxy.
+to connect to newly discovered peers through the local SOCKS5 proxy. Peer
+addresses received from others are also rebroadcast, enabling transitive
+discovery across the network.

--- a/java/RelayServer.java
+++ b/java/RelayServer.java
@@ -1,0 +1,103 @@
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * Simple relay server used for tunneling connections between peers.
+ * Each node listens on RELAY_PORT and can forward traffic to another
+ * peer when requested. The first line received from a client is treated
+ * as the target peer's address.
+ */
+public class RelayServer {
+  public static final int RELAY_PORT = 9090;
+
+  private ServerSocket serverSocket;
+  private ExecutorService executor;
+  private volatile boolean running;
+
+  /** Starts the relay server on RELAY_PORT. */
+  public void start() throws IOException {
+    serverSocket = new ServerSocket(RELAY_PORT);
+    executor = Executors.newCachedThreadPool();
+    running = true;
+    executor.execute(() -> listenLoop());
+  }
+
+  /** Main accept loop for incoming relay requests. */
+  private void listenLoop() {
+    while (running) {
+      try {
+        Socket client = serverSocket.accept();
+        executor.execute(() -> handleClient(client));
+      } catch (IOException e) {
+        if (running) {
+          System.err.println("RelayServer: accept error: " + e.getMessage());
+        }
+      }
+    }
+  }
+
+  /** Handles a single relay connection. */
+  private void handleClient(Socket client) {
+    try (BufferedReader reader = new BufferedReader(new InputStreamReader(client.getInputStream()));
+         PrintWriter writer = new PrintWriter(client.getOutputStream(), true)) {
+      String targetLine = reader.readLine();
+      if (targetLine == null) {
+        client.close();
+        return;
+      }
+      InetAddress target = InetAddress.getByName(targetLine.trim());
+      Socket targetSocket = new Socket(target, RELAY_PORT);
+      forwardStreams(client, targetSocket);
+    } catch (IOException e) {
+      System.err.println("RelayServer: failed to relay connection: " + e.getMessage());
+      try { client.close(); } catch (IOException ignored) {}
+    }
+  }
+
+  /** Bridges two sockets until either is closed. */
+  private void forwardStreams(Socket a, Socket b) throws IOException {
+    Thread t1 = new Thread(() -> copy(a, b));
+    Thread t2 = new Thread(() -> copy(b, a));
+    t1.start();
+    t2.start();
+  }
+
+  /** Utility to copy data from one socket to another. */
+  private static void copy(Socket src, Socket dst) {
+    try (InputStream in = src.getInputStream();
+         OutputStream out = dst.getOutputStream()) {
+      byte[] buf = new byte[8192];
+      int len;
+      while ((len = in.read(buf)) != -1) {
+        out.write(buf, 0, len);
+        out.flush();
+      }
+    } catch (IOException ignored) {
+    } finally {
+      try { src.close(); } catch (IOException ignored) {}
+      try { dst.close(); } catch (IOException ignored) {}
+    }
+  }
+
+  /** Stops the relay server and releases resources. */
+  public void stop() {
+    running = false;
+    try {
+      if (serverSocket != null) {
+        serverSocket.close();
+      }
+    } catch (IOException ignored) {}
+    if (executor != null) {
+      executor.shutdownNow();
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- implement `RelayServer` to forward connections between peers
- try relaying through other discovered peers in `ClientConnector`
- start/stop the relay server inside `MDNSBroadcaster`
- document the new tunneling ability in the README

## Testing
- `javac java/*.java`
- `java -cp java ribbonWorm_Main` *(fails quickly as expected due to missing peers)*

------
https://chatgpt.com/codex/tasks/task_e_683f7d2557548327a0ef068877d7560d